### PR TITLE
deps: upgrade thiserror to 1.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,22 +173,22 @@ checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "An implementation of a lockfile used in Deno"
 ring = "=0.16.20"
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.85"
-thiserror = "=1.0.38"
+thiserror = "1.0.40"
 
 [dev-dependencies]
 temp-dir = "0.1.11"


### PR DESCRIPTION
Remove version pinning so that consumers of this package can install newer versions without waiting for us to upgrade our `Cargo.toml`.

**Release notes:**

https://github.com/dtolnay/thiserror/releases/tag/1.0.40
- Update syn dependency to 2.x

https://github.com/dtolnay/thiserror/releases/tag/1.0.39
- Set html_root_url attribute

/cc @bartlomieju